### PR TITLE
refactor: improve listing API

### DIFF
--- a/rusty-response-api/src/channel/server/runner.rs
+++ b/rusty-response-api/src/channel/server/runner.rs
@@ -91,16 +91,16 @@ async fn payload(
             }
 
             // DEBUG: REMOVE THIS BLOCK IN PROD
-            sender
-                .send(ServerMessage::ServerStateChanged {
-                    status: ServerStatus::Unreachable {
-                        reason: format!("Sending from: {}", server.id),
-                        status_code: http::StatusCode::OK,
-                        body: b"TEST".to_vec(),
-                    },
-                    server: server.clone(),
-                })
-                .ok();
+            //            sender
+            //                .send(ServerMessage::ServerStateChanged {
+            //                    status: ServerStatus::Unreachable {
+            //                        reason: format!("Sending from: {}", server.id),
+            //                        status_code: http::StatusCode::OK,
+            //                        body: b"TEST".to_vec(),
+            //                    },
+            //                    server: server.clone(),
+            //                })
+            //                .ok();
         };
 
         result.await;

--- a/rusty-response-api/src/model/mod.rs
+++ b/rusty-response-api/src/model/mod.rs
@@ -5,8 +5,10 @@ mod server_log;
 mod user;
 mod user_action;
 
+mod utils;
+pub use utils::Page;
+
 pub use notifier::{Notifier, NotifierBmc, NotifierCreate};
-use serde::Deserialize;
 pub use server::{Server, ServerBmc, ServerCreate};
 pub use server_log::{ServerLog, ServerLogBmc, ServerLogCreate, ServerLogLine};
 pub use user::{User, UserBmc, UserClaims, UserCreate, UserRole};
@@ -17,21 +19,6 @@ pub use error::{ModelError, Result};
 use sqlx::sqlite::SqliteConnectOptions;
 use sqlx::{Pool, Sqlite};
 use std::path::Path;
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct PaginationArguments {
-    pub limit: i64,
-    pub offset: i64,
-}
-
-impl From<(i64, i64)> for PaginationArguments {
-    fn from(value: (i64, i64)) -> Self {
-        Self {
-            limit: value.0,
-            offset: value.1,
-        }
-    }
-}
 
 #[derive(Clone)]
 pub struct ModelManager {

--- a/rusty-response-api/src/model/server.rs
+++ b/rusty-response-api/src/model/server.rs
@@ -1,9 +1,10 @@
-use super::PaginationArguments;
 use eyre::Result;
 use serde::{Deserialize, Serialize};
 use sqlx::prelude::FromRow;
 use sqlx::{Row, Sqlite};
 use time::PrimitiveDateTime;
+
+use crate::model::Page;
 
 use super::{Ctx, ModelManager};
 
@@ -146,38 +147,6 @@ impl ServerBmc {
         Ok(updated_at)
     }
 
-    pub async fn all(mm: &ModelManager, _ctx: &Ctx) -> Result<Vec<Server>> {
-        let result = sqlx::query_as::<Sqlite, Server>("SELECT * FROM server;")
-            .fetch_all(&mm.pool)
-            .await?;
-
-        Ok(result)
-    }
-
-    pub async fn list(
-        mm: &ModelManager,
-        ctx: &Ctx,
-        args: Option<PaginationArguments>,
-    ) -> Result<Vec<Server>> {
-        let result = if let Some(args) = args {
-            sqlx::query_as::<Sqlite, Server>(
-                "SELECT * FROM server WHERE user_id = ? LIMIT ? OFFSET ?",
-            )
-            .bind(ctx.user_id)
-            .bind(args.limit)
-            .bind(args.offset)
-            .fetch_all(&mm.pool)
-            .await?
-        } else {
-            sqlx::query_as::<Sqlite, Server>("SELECT * FROM server WHERE user_id = ?")
-                .bind(ctx.user_id)
-                .fetch_all(&mm.pool)
-                .await?
-        };
-
-        Ok(result)
-    }
-
     pub async fn get_by_name(mm: &ModelManager, _ctx: &Ctx, name: &str) -> Result<Option<Server>> {
         let result = sqlx::query_as::<Sqlite, Server>("SELECT * FROM server WHERE name = ?")
             .bind(name)
@@ -207,12 +176,67 @@ impl ServerBmc {
         Ok(Some(result))
     }
 
-    pub async fn remove_by_id(mm: &ModelManager, _ctx: &Ctx, id: i64) -> Result<()> {
+    pub async fn delete(mm: &ModelManager, _ctx: &Ctx, id: i64) -> Result<()> {
         sqlx::query("DELETE FROM server WHERE id = ?")
             .bind(id)
             .execute(&mm.pool)
             .await?;
 
         Ok(())
+    }
+}
+
+// Listing API
+impl ServerBmc {
+    // Don't use in API routes, only for internal usage
+    pub async fn all(
+        mm: &ModelManager,
+        _ctx: &Ctx,
+    ) -> Result<Vec<Server>> {
+        let result = sqlx::query_as("SELECT * FROM server")
+            .fetch_all(&mm.pool)
+            .await?;
+        Ok(result)
+    }
+
+    pub async fn count(
+        mm: &ModelManager,
+        ctx: &Ctx,
+    ) -> Result<i64> {
+        let row = sqlx::query("SELECT COUNT(*) as count FROM server WHERE user_id = ?")
+            .bind(ctx.user_id)
+            .fetch_one(&mm.pool)
+            .await?;
+
+        let count = row.try_get("count")?;
+        Ok(count)
+    }
+
+    pub async fn list(
+        mm: &ModelManager,
+        ctx: &Ctx,
+        offset: i64,
+        limit: i64,
+    ) -> Result<Vec<Server>> {
+        let result = sqlx::query_as("SELECT * FROM server WHERE user_id = ? LIMIT ? OFFSET ?")
+            .bind(ctx.user_id)
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(&mm.pool)
+            .await?;
+
+        Ok(result)
+    }
+
+    pub async fn page(
+        mm: &ModelManager,
+        ctx: &Ctx,
+        offset: i64,
+        limit: i64,
+    ) -> Result<Page<Server>> {
+        let items = Self::list(mm, ctx, offset, limit).await?;
+        let count = Self::count(mm, ctx).await?;
+
+        Ok(Page::new(items, count, limit, offset))
     }
 }

--- a/rusty-response-api/src/model/server_log.rs
+++ b/rusty-response-api/src/model/server_log.rs
@@ -5,7 +5,7 @@ use time::PrimitiveDateTime;
 
 use crate::{
     ModelManager,
-    model::{Ctx, Server},
+    model::{Ctx, Page, Server},
 };
 
 #[derive(Debug, Clone, Serialize)]
@@ -95,13 +95,35 @@ impl ServerLogBmc {
         Ok(log)
     }
 
-    pub async fn all_limited(
+    pub async fn delete(mm: &ModelManager, _ctx: &Ctx, id: i64) -> Result<()> {
+        sqlx::query("DELETE FROM server_log WHERE id = ?")
+            .bind(id)
+            .execute(&mm.pool)
+            .await?;
+
+        Ok(())
+    }
+}
+
+// Listing API
+impl ServerLogBmc {
+    pub async fn count(mm: &ModelManager, _ctx: &Ctx) -> Result<i64> {
+        let row = sqlx::query("SELECT COUNT(*) as count FROM server_log")
+            .fetch_one(&mm.pool)
+            .await?;
+        let count = row.try_get("count")?;
+        Ok(count)
+    }
+
+    pub async fn list(
         mm: &ModelManager,
         _ctx: &Ctx,
+        id: i64,
         offset: i64,
         limit: i64,
     ) -> Result<Vec<ServerLog>> {
-        let logs = sqlx::query_as::<Sqlite, ServerLog>("SELECT * FROM server_log LIMIT ? OFFSET ?")
+        let logs = sqlx::query_as::<Sqlite, ServerLog>("SELECT * FROM server_log WHERE server_id = ? LIMIT ? OFFSET ?")
+            .bind(id)
             .bind(limit)
             .bind(offset)
             .fetch_all(&mm.pool)
@@ -110,20 +132,16 @@ impl ServerLogBmc {
         Ok(logs)
     }
 
-    pub async fn all(mm: &ModelManager, _ctx: &Ctx) -> Result<Vec<ServerLog>> {
-        let logs = sqlx::query_as::<Sqlite, ServerLog>("SELECT * FROM server_log")
-            .fetch_all(&mm.pool)
-            .await?;
+    pub async fn page(
+        mm: &ModelManager,
+        _ctx: &Ctx,
+        id: i64,
+        offset: i64,
+        limit: i64,
+    ) -> Result<Page<ServerLog>> {
+        let items = Self::list(mm, _ctx, id, offset, limit).await?;
+        let count = Self::count(mm, _ctx).await?;
 
-        Ok(logs)
-    }
-
-    pub async fn delete(mm: &ModelManager, _ctx: &Ctx, id: i64) -> Result<()> {
-        sqlx::query("DELETE FROM server_log WHERE id = ?")
-            .bind(id)
-            .execute(&mm.pool)
-            .await?;
-
-        Ok(())
+        Ok(Page::new(items, count, limit, offset))
     }
 }

--- a/rusty-response-api/src/model/utils.rs
+++ b/rusty-response-api/src/model/utils.rs
@@ -1,0 +1,20 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Page<T> {
+    items: Vec<T>,
+    total: i64,
+    limit: i64,
+    offset: i64,
+}
+
+impl<T> Page<T> {
+    pub fn new(items: Vec<T>, total: i64, limit: i64, offset: i64) -> Self {
+        Self {
+            items,
+            total,
+            limit,
+            offset,
+        }
+    }
+}

--- a/rusty-response-api/src/web/mod.rs
+++ b/rusty-response-api/src/web/mod.rs
@@ -43,6 +43,10 @@ pub fn app<S>(state: AppState) -> Router<S> {
             "/api/v1/notify/",
             routes::notify_routes(AppState::clone(&state)),
         )
+        .nest(
+            "/api/v1/logs/server/",
+            routes::server_log_routes(AppState::clone(&state)),
+        )
         .layer(tower_cookies::CookieManagerLayer::new())
         .layer(CorsLayer::very_permissive())
         .with_state(AppState::clone(&state))

--- a/rusty-response-api/src/web/routes/mod.rs
+++ b/rusty-response-api/src/web/routes/mod.rs
@@ -1,22 +1,17 @@
 mod middlewares;
+use tokio::sync::mpsc::UnboundedSender;
 
 mod notifier;
 mod server;
+mod server_log;
 mod user;
 
 pub use notifier::routes as notify_routes;
-use serde::Deserialize;
 pub use server::routes as server_routes;
-use tokio::sync::mpsc::UnboundedSender;
+pub use server_log::routes as server_log_routes;
 pub use user::routes as user_routes;
 
 use crate::{ModelManager, channel::ControlMessage, notify::NotifyManager};
-
-#[derive(Deserialize)]
-pub struct PaginationQuery {
-    limit: Option<i64>,
-    offset: Option<i64>,
-}
 
 pub struct RawState {
     pub mm: ModelManager,

--- a/rusty-response-api/src/web/routes/server_log.rs
+++ b/rusty-response-api/src/web/routes/server_log.rs
@@ -1,0 +1,45 @@
+use axum::{
+    Json, Router,
+    extract::{Path, Query, State},
+    middleware,
+    response::{IntoResponse, Response},
+    routing::get,
+};
+use reqwest::StatusCode;
+
+use crate::{
+    Ctx,
+    model::{ServerBmc, ServerLogBmc, UserRole},
+    web::{AppState, WebError, routes::middlewares::verify_token_middleware, utils::PageQuery},
+};
+
+pub fn routes<S>(state: AppState) -> Router<S> {
+    Router::new()
+        .route("/{id}", get(get_server_logs))
+        .layer(middleware::from_fn_with_state(
+            AppState::clone(&state),
+            verify_token_middleware,
+        ))
+        .with_state(state)
+}
+
+pub async fn get_server_logs(
+    State(state): State<AppState>,
+    ctx: Ctx,
+    Path(id): Path<i64>,
+    Query(query): Query<PageQuery>,
+) -> Result<Response, WebError> {
+    let server = ServerBmc::get_by_id(&state.mm, &ctx, id).await?;
+    if server.is_none() {
+        return Err(WebError::ServerNotFound);
+    }
+    let server = server.unwrap();
+
+    if server.user_id != ctx.user_id && !matches!(ctx.role, UserRole::Admin) {
+        return Err(WebError::ServerNotAllowed);
+    }
+
+    let logs = ServerLogBmc::page(&state.mm, &ctx, id, query.offset, query.limit).await?;
+
+    Ok((StatusCode::OK, Json(logs)).into_response())
+}

--- a/rusty-response-api/src/web/utils.rs
+++ b/rusty-response-api/src/web/utils.rs
@@ -1,8 +1,15 @@
+use serde::{Deserialize, Serialize};
 use tokio::{signal, sync::mpsc};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::channel::ControlMessage;
+
+#[derive(Deserialize, Serialize)]
+pub struct PageQuery {
+    pub limit: i64,
+    pub offset: i64,
+}
 
 pub async fn shutdown_signal(
     token: CancellationToken,


### PR DESCRIPTION
## Changelog
Now all listing API, e.g "get all records of XXX" is well(i hope) structured to get expected output.

```json
{
    "items": [],
    "total": 0,
    "limit": 10,
    "offset": 0
}
```
`items` field contains an array of elements requested, e.g list of servers, notifiers or server_logs

`total` field stores a total amount of records in database. It also depends on user which is requesting. We won't show the unusable amount of servers(as example). This field will only show the actual amount of records which is available to that user. E.g, he created 10 servers and that fields will show 10, nothing more. TL;DR. Shows only "owned" amount of records

`limit` this field is just copied from request query params.
`offset` same as above

Here is the `Page` structure, its just deserialized version of above, just FYI
```rust
#[derive(Debug, Serialize, Deserialize)]
pub struct Page<T> {
    items: Vec<T>,
    total: i64,
    limit: i64,
    offset: i64,
}
```

### Listing API
All future listings API will be structured the same as in this PR.
The most critical change here is that it will change required query parameters for all listing routes.

For example, we want to request one page of the server logs, so we make a request like this
`/api/v1/logs/server/1?limit=10&offset=0`. See? Now, `limit` and `offset` parameters are required. For people not familiar with databases and their OFFSET and LIMIT, here is a short intro:
```
LIMIT - will limit the response by N records
OFFSET - will skip first N records before selecting

combining them allows to request some "pages" of data
```

Yeah, so, now, every listing API follows this rules. Same with `/api/v1/server/` and `/api/v1/notify/`

### Routes
```
/api/v1/server/?limit=10&offset=0
/api/v1/notify/1?limit=10&offset=0
/api/v1/logs/server/1?limit=10&offset=0
```
@flionx check this out :)
That's all!






