### PR TITLE
feat: add more one route for notifiers

### DIFF
--- a/rusty-response-api/src/web/error.rs
+++ b/rusty-response-api/src/web/error.rs
@@ -1,6 +1,5 @@
 use axum::{Json, http::StatusCode, response::IntoResponse};
 use serde::Serialize;
-use serde_json::json;
 use utoipa::ToSchema;
 
 use crate::crypt::CryptError;


### PR DESCRIPTION
One more route for notifiers. It will be like
GET `/api/v1/notify/`
it will list all notifiers for the current logged user.

This PR also contains fix for 
GET `/api/v1/notify/server/{id}`
This route has been returning all notifiers the user have in all servers. It was a wrong behaviour. Now it should return only notifiers for the specified server.

@flionx 